### PR TITLE
Added overridable pre addition processing

### DIFF
--- a/accordionrecycler/src/main/java/com/izikode/izilib/accordionrecycler/AccordionRecyclerAdapter.kt
+++ b/accordionrecycler/src/main/java/com/izikode/izilib/accordionrecycler/AccordionRecyclerAdapter.kt
@@ -97,6 +97,9 @@ abstract class AccordionRecyclerAdapter<ViewHolder, DataType> : AdapterContract.
         presenter.addEnclosedItems(enclosingPosition, enclosedItemMutableList)
     }
 
+    override fun processForAdditionalItems(position: Int, item: AccordionRecyclerData<out DataType?>?)
+            : Array<out AccordionRecyclerData<out DataType?>?> = arrayOf(item)
+
     /**
      * Removes all current data.
      */

--- a/accordionrecycler/src/main/java/com/izikode/izilib/accordionrecycler/adaptercomponents/AdapterContract.kt
+++ b/accordionrecycler/src/main/java/com/izikode/izilib/accordionrecycler/adaptercomponents/AdapterContract.kt
@@ -117,6 +117,15 @@ interface AdapterContract {
             where ViewHolder : AccordionRecyclerViewHolder<out AccordionRecyclerData<out DataType?>> {
 
         /**
+         * Processes the data being added for any additions coming from edge cases, such as null data or empty enclosed data.
+         *
+         * @param position  The position of the item currently being added and being processed.
+         * @param item  The item currently being added and being processed.
+         * @return The post process array of items.
+         */
+        abstract fun processForAdditionalItems(position: Int, item: AccordionRecyclerData<out DataType?>?): Array<out AccordionRecyclerData<out DataType?>?>
+
+        /**
          * Creates a new ViewHolder instance for the provided parent, based on the provided viewType.
          *
          * @param parent  The parent ViewGroup of the ViewHolder.
@@ -212,6 +221,15 @@ interface AdapterContract {
          * @param enclosedItemMutableList  The mutable list to be added as children.
          */
         fun addEnclosedItems(enclosingPosition: Int, enclosedItemMutableList: MutableList<out AccordionRecyclerData<out DataType?>>)
+
+        /**
+         * Processes the data being added for any additions coming from edge cases, such as null data or empty enclosed data.
+         *
+         * @param position  The position of the item currently being added and being processed.
+         * @param item  The item currently being added and being processed.
+         * @return The post process array of items.
+         */
+        fun processForAdditionalItems(position: Int, item: AccordionRecyclerData<out DataType?>?): Array<out AccordionRecyclerData<out DataType?>?>
 
         /**
          * Removes all current data.

--- a/accordionrecycler/src/main/java/com/izikode/izilib/accordionrecycler/adaptercomponents/AdapterModel.kt
+++ b/accordionrecycler/src/main/java/com/izikode/izilib/accordionrecycler/adaptercomponents/AdapterModel.kt
@@ -7,9 +7,9 @@ import java.util.*
 
 class AdapterModel<DataType> : AdapterContract.Model<DataType> {
 
-    private lateinit var presenter: AdapterContract.Presenter<out DataType>
+    private lateinit var presenter: AdapterContract.Presenter<DataType>
 
-    fun initialize(presenter: AdapterContract.Presenter<out DataType>) {
+    fun initialize(presenter: AdapterContract.Presenter<DataType>) {
         this.presenter = presenter
     }
 
@@ -82,28 +82,29 @@ class AdapterModel<DataType> : AdapterContract.Model<DataType> {
             }
 
         dataArray.forEach { accordionRecyclerData ->
+            presenter.processForAdditionalItems(startFrom, accordionRecyclerData).forEach { processedData ->
+                val mainWrapper = Wrapper(
+                    processedData?.viewType ?: -1,
+                    containingData,
+                    processedData?.mainData
+                )
 
-            val mainWrapper = Wrapper(
-                accordionRecyclerData.viewType,
-                containingData,
-                accordionRecyclerData.mainData
-            )
+                /* Add main data */
+                dataList.add(startFrom, mainWrapper)
 
-            /* Add main data */
-            dataList.add(startFrom, mainWrapper)
+                sum += 1
+                startFrom += 1
 
-            sum += 1
-            startFrom += 1
+                /* Update map list if needed */
+                containingList?.add(WeakReference(mainWrapper))
 
-            /* Update map list if needed */
-            containingList?.add(WeakReference(mainWrapper))
+                /* If exist, add enclosed data array recursively */
+                processedData?.enclosedDataArray?.let {
+                    val secondarySum = recursivelyAddAllAndReturnSum(startFrom, it, mainWrapper)
 
-            /* If exist, add enclosed data array recursively */
-            accordionRecyclerData.enclosedDataArray?.let {
-                val secondarySum = recursivelyAddAllAndReturnSum(startFrom, it, mainWrapper)
-
-                sum += secondarySum
-                startFrom += secondarySum
+                    sum += secondarySum
+                    startFrom += secondarySum
+                }
             }
         }
 

--- a/accordionrecycler/src/main/java/com/izikode/izilib/accordionrecycler/adaptercomponents/AdapterPresenter.kt
+++ b/accordionrecycler/src/main/java/com/izikode/izilib/accordionrecycler/adaptercomponents/AdapterPresenter.kt
@@ -7,7 +7,7 @@ import com.izikode.izilib.accordionrecycler.AccordionRecyclerViewHolder
 class AdapterPresenter<DataType>(
 
     private val model: AdapterContract.Model<DataType>,
-    private val view: AdapterContract.View<out AccordionRecyclerViewHolder<out AccordionRecyclerData<out DataType?>>, out DataType>
+    private val view: AdapterContract.View<out AccordionRecyclerViewHolder<out AccordionRecyclerData<out DataType?>>, DataType>
 
 ) : AdapterContract.Presenter<DataType> {
 
@@ -48,6 +48,8 @@ class AdapterPresenter<DataType>(
     override fun addEnclosedItems(enclosingPosition: Int, enclosedItemMutableList: MutableList<out AccordionRecyclerData<out DataType?>>) {
         model.addEnclosedData(enclosingPosition, enclosedItemMutableList.toTypedArray())
     }
+
+    override fun processForAdditionalItems(position: Int, item: AccordionRecyclerData<out DataType?>?): Array<out AccordionRecyclerData<out DataType?>?> = view.processForAdditionalItems(position, item)
 
     override fun clearItems() {
         model.clearData()
@@ -104,7 +106,7 @@ class AdapterPresenter<DataType>(
     companion object {
 
         @JvmStatic
-        fun <DataType> make(view: AdapterContract.View<out AccordionRecyclerViewHolder<out AccordionRecyclerData<out DataType?>>, out DataType>)
+        fun <DataType> make(view: AdapterContract.View<out AccordionRecyclerViewHolder<out AccordionRecyclerData<out DataType?>>, DataType>)
                 : AdapterPresenter<DataType> {
 
             val model = AdapterModel<DataType>()

--- a/app/src/main/java/com/izikode/izilib/accordionrecyclerdemo/MainAccordionAdapter.kt
+++ b/app/src/main/java/com/izikode/izilib/accordionrecyclerdemo/MainAccordionAdapter.kt
@@ -2,6 +2,7 @@ package com.izikode.izilib.accordionrecyclerdemo
 
 import android.view.ViewGroup
 import com.izikode.izilib.accordionrecycler.AccordionRecyclerAdapter
+import com.izikode.izilib.accordionrecycler.AccordionRecyclerData
 import com.izikode.izilib.accordionrecycler.AccordionRecyclerPosition
 import com.izikode.izilib.accordionrecyclerdemo.data.*
 import com.izikode.izilib.accordionrecyclerdemo.viewholder.*
@@ -19,11 +20,27 @@ class MainAccordionAdapter : AccordionRecyclerAdapter<ColorViewHolder<out ColorD
             }
         }
 
+    override fun processForAdditionalItems(position: Int, item: AccordionRecyclerData<out ColorData?>?)
+            : Array<out AccordionRecyclerData<out ColorData?>?> = item?.let {
+
+                    if (it is PinkData && it.enclosedDataArray.isNullOrEmpty()) {
+                        arrayOf(
+                            it.apply {
+                                enclosedDataArray = arrayOf(EmptyPinkViewHolder.EmptyPinkData())
+                            }
+                        )
+                    } else {
+                        super.processForAdditionalItems(position, item)
+                    }
+
+                } ?: super.processForAdditionalItems(position, item)
+
     override fun buildViewHolder(parent: ViewGroup, viewType: Int): ColorViewHolder<out ColorData> =
         when(viewType) {
 
             RedViewHolder.VIEW_TYPE -> RedViewHolder(parent)
             PinkViewHolder.VIEW_TYPE -> PinkViewHolder(parent)
+            EmptyPinkViewHolder.VIEW_TYPE -> EmptyPinkViewHolder(parent)
             WhiteViewHolder.VIEW_TYPE -> WhiteViewHolder(parent)
 
             else -> GrayViewHolder(parent)
@@ -56,6 +73,10 @@ class MainAccordionAdapter : AccordionRecyclerAdapter<ColorViewHolder<out ColorD
                         }
                     }
                 }
+
+            is EmptyPinkViewHolder -> viewHolder.apply {
+                update(data as EmptyPinkViewHolder.EmptyPinkData?, overallPosition, enclosedPosition, totalEnclosedItemsSum)
+            }
 
             is WhiteViewHolder -> viewHolder.apply {
                     update(data as WhiteData?, overallPosition, enclosedPosition)

--- a/app/src/main/java/com/izikode/izilib/accordionrecyclerdemo/MainActivity.kt
+++ b/app/src/main/java/com/izikode/izilib/accordionrecyclerdemo/MainActivity.kt
@@ -11,7 +11,7 @@ class MainActivity : AppCompatActivity() {
 
     private val colorData = arrayListOf<ColorData>().apply {
         add(GrayData("1 gray"))
-        addAll(redArray(5))
+        addAll(redArray(2))
         add(GrayData("2 gray"))
         add(GrayData("3 gray"))
         addAll(redArray(9))
@@ -46,7 +46,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun redArray(sum: Int): Array<RedData> = Array(sum) { index ->
             RedData("$index red").apply {
-                enclosedDataArray = pinkArray(index, Random().nextInt(9))
+                enclosedDataArray = pinkArray(index, Random().nextInt(8) + 1)
             }
         }
 

--- a/app/src/main/java/com/izikode/izilib/accordionrecyclerdemo/viewholder/EmptyPinkViewHolder.kt
+++ b/app/src/main/java/com/izikode/izilib/accordionrecyclerdemo/viewholder/EmptyPinkViewHolder.kt
@@ -1,0 +1,115 @@
+package com.izikode.izilib.accordionrecyclerdemo.viewholder
+
+import android.support.constraint.ConstraintLayout
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import com.izikode.izilib.accordionrecycler.AccordionRecyclerPosition
+import com.izikode.izilib.accordionrecyclerdemo.R
+import com.izikode.izilib.accordionrecyclerdemo.data.ColorData
+import com.izikode.izilib.accordionrecyclerdemo.data.PinkData
+
+class EmptyPinkViewHolder(parent: ViewGroup) : ColorViewHolder<EmptyPinkViewHolder.EmptyPinkData>(parent, R.layout.view_holder_empty_pink) {
+
+    private val container by lazy { itemView.findViewById<ConstraintLayout>(R.id.pink_container) }
+    private val text by lazy { itemView.findViewById<TextView>(R.id.pink_text) }
+    private val topShadow by lazy { itemView.findViewById<View>(R.id.pink_topShadow) }
+    private val bottomShadow by lazy { itemView.findViewById<View>(R.id.pink_bottomShadow) }
+    private val divider by lazy { itemView.findViewById<View>(R.id.pink_divider) }
+
+    var onClick: ((position: Int, enclosedSum: Int) -> Unit)? = null
+
+    override var data: EmptyPinkData? = null
+        set(value) {
+            text.text = value?.text
+            field = value
+        }
+
+    var enclosedSum: Int = 0
+
+    fun update(data: EmptyPinkData?, overallPosition: AccordionRecyclerPosition, enclosedPosition: AccordionRecyclerPosition, sumOfTotalEnclosedItems: Int) {
+        this.data = data
+        this.enclosedSum = sumOfTotalEnclosedItems
+
+        container.setBackgroundResource(
+            when (overallPosition) {
+
+                AccordionRecyclerPosition.BOTTOM -> R.drawable.empty_pink_background_bottom
+
+                else -> R.drawable.empty_pink_background_middle
+
+            }
+        )
+
+        when {
+
+            enclosedPosition == AccordionRecyclerPosition.SINGLE && sumOfTotalEnclosedItems == 0 -> {
+                topShadow.visibility = View.VISIBLE
+                bottomShadow.visibility = View.VISIBLE
+                divider.visibility = View.INVISIBLE
+            }
+
+            enclosedPosition == AccordionRecyclerPosition.SINGLE -> {
+                topShadow.visibility = View.VISIBLE
+                bottomShadow.visibility = View.INVISIBLE
+                divider.visibility = View.INVISIBLE
+            }
+
+            enclosedPosition == AccordionRecyclerPosition.TOP && sumOfTotalEnclosedItems == 0 -> {
+                topShadow.visibility = View.VISIBLE
+                bottomShadow.visibility = View.INVISIBLE
+                divider.visibility = View.VISIBLE
+            }
+
+            enclosedPosition == AccordionRecyclerPosition.TOP -> {
+                topShadow.visibility = View.VISIBLE
+                bottomShadow.visibility = View.INVISIBLE
+                divider.visibility = View.INVISIBLE
+            }
+
+            enclosedPosition == AccordionRecyclerPosition.BOTTOM && sumOfTotalEnclosedItems == 0 -> {
+                topShadow.visibility = View.INVISIBLE
+                bottomShadow.visibility = View.VISIBLE
+                divider.visibility = View.INVISIBLE
+            }
+
+            enclosedPosition == AccordionRecyclerPosition.BOTTOM -> {
+                topShadow.visibility = View.INVISIBLE
+                bottomShadow.visibility = View.INVISIBLE
+                divider.visibility = View.INVISIBLE
+            }
+
+            enclosedPosition == AccordionRecyclerPosition.MIDDLE && sumOfTotalEnclosedItems == 0 -> {
+                topShadow.visibility = View.INVISIBLE
+                bottomShadow.visibility = View.INVISIBLE
+                divider.visibility = View.VISIBLE
+            }
+
+            else -> {
+                topShadow.visibility = View.INVISIBLE
+                bottomShadow.visibility = View.INVISIBLE
+                divider.visibility = View.INVISIBLE
+            }
+
+        }
+    }
+
+    init {
+        container.setOnClickListener {
+            onClick?.invoke(layoutPosition, enclosedSum)
+        }
+    }
+
+    companion object {
+
+        const val VIEW_TYPE = 31
+
+    }
+
+    class EmptyPinkData : ColorData(VIEW_TYPE, null) {
+
+        override var text: String = "Nothing to see here"
+
+    }
+
+}

--- a/app/src/main/res/drawable/empty_pink_background_bottom.xml
+++ b/app/src/main/res/drawable/empty_pink_background_bottom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:top="-2dp">
+
+        <shape android:shape="rectangle">
+
+            <stroke android:color="@android:color/black"
+                    android:width="1dp" />
+
+            <corners android:bottomLeftRadius="8dp"
+                     android:bottomRightRadius="8dp" />
+
+            <solid android:color="#ffcce6" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/empty_pink_background_middle.xml
+++ b/app/src/main/res/drawable/empty_pink_background_middle.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:top="-2dp"
+        android:bottom="-2dp">
+
+        <shape android:shape="rectangle">
+
+            <stroke android:color="@android:color/black"
+                    android:width="1dp" />
+
+            <solid android:color="#ffcce6" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/empty_pink_background_top.xml
+++ b/app/src/main/res/drawable/empty_pink_background_top.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:bottom="-2dp">
+
+        <shape android:shape="rectangle">
+
+            <stroke android:color="@android:color/black"
+                    android:width="1dp" />
+
+            <corners android:topLeftRadius="8dp"
+                     android:topRightRadius="8dp" />
+
+            <solid android:color="#ffcce6" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/layout/view_holder_empty_pink.xml
+++ b/app/src/main/res/layout/view_holder_empty_pink.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout android:id="@+id/pink_container"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="20dp"
+    android:background="#ffcce6"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <TextView android:id="@+id/pink_text"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:textColor="@android:color/black"
+        android:gravity="center" />
+
+    <View android:id="@+id/pink_topShadow"
+        android:layout_width="match_parent"
+        android:layout_height="4dp"
+        android:background="@drawable/shadow_background_top"
+        android:alpha=".2"
+        android:layout_marginStart="1dp"
+        android:layout_marginEnd="1dp" />
+
+    <View android:id="@+id/pink_bottomShadow"
+        android:layout_width="match_parent"
+        android:layout_height="4dp"
+        android:background="@drawable/shadow_background_bottom"
+        android:alpha=".2"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginStart="1dp"
+        android:layout_marginEnd="1dp" />
+
+    <View android:id="@+id/pink_divider"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:background="@android:color/white"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginStart="1dp"
+        android:layout_marginEnd="1dp" />
+</android.support.constraint.ConstraintLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,9 @@ buildscript {
                 ],
 
                 Build : [
-                        CODE    : 1,
+                        CODE    : 2,
                         MAJOR   : 0,
-                        MINOR   : 1
+                        MINOR   : 2
                 ]
         ]
     }


### PR DESCRIPTION
Before an item gets added to the actual data list, it gets passed through a processing phase, which has been made overridable. This was added to cover cases of null main data or empty enclosed data, for which the user may want to show a visual representation of the case, without having to temper with his original data.